### PR TITLE
feat(llm): 新增 Ollama LLM 适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,15 @@ python starter.py asr
 | [Qwen/Qwen-7B-Chat](https://huggingface.co/Qwen/Qwen-7B-Chat) | 中英     | ✅️        | 11.5 GiB                                                     |
 | [01-ai/Yi-6B-Chat](https://www.modelscope.cn/models/01ai/Yi-6B-Chat) | 中英     | ❌️        | 10.0 GiB                                                     |
 | [augmxnt/shisa-7b-v1](https://huggingface.co/augmxnt/shisa-7b-v1) | 日英     | ❌️        | 11.4 GiB                                                     |
+| [Ollama](https://github.com/ollama/ollama)                   | 多语     | ✅️        | 取决于本地模型                                               |
 
 > [!NOTE]
 >
 > 1. [THUDM/chatglm3-6b](https://github.com/THUDM/ChatGLM3) 偶尔存在**中文夹杂英文**的现象，且量化精度越低这种现象越严重。
 > 2. [THUDM/GLM-4](https://github.com/THUDM/GLM-4)  在工具调用时返回的 JSON 字符串高概率存在 **JSON 语法错误**。
 > 3. [Qwen/Qwen-7B-Chat](https://huggingface.co/Qwen/Qwen-7B-Chat) 测试时发现使用多卡推理可能会**报错**，因此您应该使用**单卡推理**。
-
+> 4. [Ollama](https://github.com/ollama/ollama) 确保本机已安装并启动 **Ollama 服务** ，默认 API 地址为 `http://localhost:11434`。
+> 
 ### 自动语音识别模型
 
 识别一段自然语言语音，将其内容转换为文本字符串。

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -48,6 +48,12 @@ LLM:
       model_path: "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B" # Directory of the model
       max_length: 23000
       tensor_parallel_size: 2
+    ollama:
+      api_url: "http://localhost:11434"  # Ollama API URL
+      model_name: "gemma3:1b"  # Ollama model name (e.g., llama2, mistral, qwen, deepseek-r1, etc.)
+      temperature: 0.7
+      top_p: 0.95
+      timeout: 60
 
 ImgCap:
   id: "Salesforce/blip-image-captioning-large" # The model you want to use

--- a/llm/ollama/config.py
+++ b/llm/ollama/config.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class OllamaModelConfig:
+    api_url: str = "http://localhost:11434"  # Ollama API 地址
+    # api_url: str = "http://host.docker.internal:11434"  # Ollama API 地址
+    model_name: str = "gemma3:1b"  # Ollama 模型名称
+    temperature: float = 0.7
+    top_p: float = 0.95
+    timeout: int = 60  # 请求超时时间（秒）

--- a/llm/ollama/model.py
+++ b/llm/ollama/model.py
@@ -1,0 +1,201 @@
+"""
+Ollama API integration for ZerolanCore
+Documentation: https://github.com/ollama/ollama/blob/main/docs/api.md
+"""
+import json
+import requests
+from loguru import logger
+from typing import Iterator
+
+from common.abs_model import AbstractModel
+from common.decorator import log_model_loading
+from llm.ollama.config import OllamaModelConfig
+from zerolan.data.pipeline.llm import LLMQuery, LLMPrediction, Conversation
+
+
+class OllamaModel(AbstractModel):
+
+    def __init__(self, config: OllamaModelConfig):
+        super().__init__()
+        self.model_id = "ollama"
+        self._api_url = config.api_url.rstrip('/')
+        self._model_name = config.model_name
+        self._temperature = config.temperature
+        self._top_p = config.top_p
+        self._timeout = config.timeout
+
+    @log_model_loading("Ollama")
+    def load_model(self):
+        """
+        验证 Ollama 服务是否可用
+        """
+        try:
+            # 检查 Ollama 服务是否运行
+            response = requests.get(f"{self._api_url}/api/tags", timeout=self._timeout)
+            if response.status_code == 200:
+                models = response.json().get('models', [])
+                model_names = [m['name'] for m in models]
+                logger.info(f"Ollama 服务已连接，可用模型: {model_names}")
+                
+                # 检查指定的模型是否存在
+                if not any(self._model_name in name for name in model_names):
+                    logger.warning(f"模型 '{self._model_name}' 未找到，但服务正常运行")
+                    raise RuntimeError(
+                        f"Ollama model '{self._model_name}' not found. "
+                        f"Run `ollama pull {self._model_name}`."
+                    )
+                else:
+                    logger.info(f"模型 '{self._model_name}' 已就绪")
+            else:
+                logger.error(f"Ollama 服务响应异常: {response.status_code}")
+                raise RuntimeError(f"Ollama service error: {response.status_code}")
+        except requests.exceptions.RequestException as e:
+            logger.error(f"无法连接到 Ollama 服务 ({self._api_url}): {e}")
+            logger.warning("请确保 Ollama 服务正在运行")
+            raise RuntimeError(f"Ollama service unavailable: {self._api_url}") from e
+
+    def predict(self, llm_query: LLMQuery) -> LLMPrediction:
+        """
+        使用 Ollama API 进行推理
+        Args:
+            llm_query: See zerolan.data.pipeline.llm.LLMQuery
+
+        Returns: See zerolan.data.pipeline.llm.LLMPrediction
+        """
+        messages = self._to_ollama_format(llm_query)
+        
+        payload = {
+            "model": self._model_name,
+            "messages": messages,
+            "stream": False,
+            "options": {
+                "temperature": self._temperature,
+                "top_p": self._top_p
+            }
+        }
+
+        try:
+            response = requests.post(
+                f"{self._api_url}/api/chat",
+                json=payload,
+                timeout=self._timeout
+            )
+            response.raise_for_status()
+            
+            result = response.json()
+            if "error" in result:
+                raise RuntimeError(result["error"])
+            if "message" not in result or "content" not in result["message"]:
+                raise RuntimeError("Ollama response missing message content.")
+            assistant_message = result['message']['content']
+            
+            logger.debug(f"Ollama 响应: {assistant_message}")
+            
+            return self._to_pipeline_format(assistant_message, messages)
+            
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Ollama API 请求失败: {e}")
+            raise
+
+    def stream_predict(self, llm_query: LLMQuery) -> Iterator[LLMPrediction]:
+        """
+        使用 Ollama API 进行流式推理
+        Args:
+            llm_query: See zerolan.data.pipeline.llm.LLMQuery
+
+        Returns: Iterator of zerolan.data.pipeline.llm.LLMPrediction
+        """
+        messages = self._to_ollama_format(llm_query)
+        
+        payload = {
+            "model": self._model_name,
+            "messages": messages,
+            "stream": True,
+            "options": {
+                "temperature": self._temperature,
+                "top_p": self._top_p
+            }
+        }
+
+        try:
+            response = requests.post(
+                f"{self._api_url}/api/chat",
+                json=payload,
+                stream=True,
+                timeout=self._timeout
+            )
+            response.raise_for_status()
+            
+            accumulated_response = ""
+            
+            for line in response.iter_lines():
+                if line:
+                    try:
+                        chunk = json.loads(line.decode('utf-8'))
+                        if "error" in chunk:
+                            raise RuntimeError(chunk["error"])
+                        if 'message' in chunk:
+                            content = chunk['message'].get('content', '')
+                            accumulated_response += content
+                            
+                            logger.debug(f"流式响应块: {content}")
+                            
+                            yield self._to_pipeline_format(accumulated_response, messages)
+                            
+                            # 如果是最后一个块
+                            if chunk.get('done', False):
+                                break
+                        elif chunk.get('done', False):
+                            break
+                    except json.JSONDecodeError as e:
+                        logger.warning(f"解析流式响应失败: {e}")
+                        continue
+                        
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Ollama 流式 API 请求失败: {e}")
+            raise
+
+    @staticmethod
+    def _to_ollama_format(llm_query: LLMQuery) -> list[dict]:
+        """
+        转换为 Ollama API 格式
+        Ollama 格式: [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]
+        """
+        messages = []
+
+        # 添加历史对话
+        for chat in llm_query.history:
+            messages.append({
+                "role": OllamaModel._role_to_str(chat.role),
+                "content": chat.content
+            })
+        
+        # 添加当前用户输入
+        messages.append({
+            "role": "user",
+            "content": llm_query.text
+        })
+        
+        return messages
+
+    @staticmethod
+    def _to_pipeline_format(response: str, messages: list[dict]) -> LLMPrediction:
+        """
+        转换为 Pipeline 标准格式
+        """
+        # Include the current user turn from messages, then append assistant response.
+        new_history = [
+            Conversation(role=OllamaModel._role_to_str(m["role"]), content=m["content"])
+            for m in messages
+        ]
+        new_history.append(Conversation(role="assistant", content=response))
+
+        return LLMPrediction(response=response, history=new_history)
+
+    @staticmethod
+    def _role_to_str(role) -> str:
+        if hasattr(role, "value"):
+            role = role.value
+        if isinstance(role, str):
+            return role
+        return str(role)

--- a/llm/ollama/requirements.txt
+++ b/llm/ollama/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/starter.py
+++ b/starter.py
@@ -79,6 +79,10 @@ def llm_app() -> AbstractApplication:
             from llm.deepseek.model import DeepSeekLLMModel as Model
             from llm.deepseek.config import DeepSeekModelConfig as Config
             return Model(Config(**model_cfg))
+        elif llm_id == "ollama":
+            from llm.ollama.model import OllamaModel as Model
+            from llm.ollama.config import OllamaModelConfig as Config
+            return Model(Config(**model_cfg))
         else:
             raise NameError(f"No such model name (id) {llm_id}")
 


### PR DESCRIPTION
1.变更内容：
新增 Ollama 作为 LLM 后端，并完成相关配置接入与初始化逻辑。
补充 Ollama 使用文档。

2.变更目的：
让用户在不改动上层管线接口的前提下，可以在本地模型与 Ollama 之间无缝切换，复用同一套 Pipeline 调用方式。