### PR TITLE
新增glm-4量化模型支持||新增防御模型部分

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $env:HF_ENDPOINT = "https://hf-mirror.com"
 > 5. [DeepSeek-R1-Distill-Llama-8B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B) 支持双卡推理，但是存在语句异常中断问题，原因不详。
 > 6. [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B) 支持双卡推理，但是其显存已经超出两张 NVIDIA GeForce RTX 4090 的极限。
 > 7. [Ollama](https://github.com/ollama/ollama) 确保本机已安装并启动 **Ollama 服务**。
-> 8. [legraphista/glm-4-9b-chat-GGUF](https://huggingface.co/legraphista/glm-4-9b-chat-GGUF) 是基于 [THUDM/GLM-4](https://github.com/THUDM/GLM-4) 的量化模型版本，因此除了本项目启动时需要设置模型 id 以外，其他项目例如 [ZerolanLiveRobot](https://github.com/AkagawaTsurunaki/ZerolanLiveRobot) 完全继承了 [THUDM/GLM-4](https://github.com/THUDM/GLM-4) 的接口。
+> 8. [legraphista/glm-4-9b-chat-GGUF](https://huggingface.co/legraphista/glm-4-9b-chat-GGUF) 是基于 [THUDM/GLM-4](https://github.com/THUDM/GLM-4) 的量化模型版本，因此其他项目例如 [ZerolanLiveRobot](https://github.com/AkagawaTsurunaki/ZerolanLiveRobot) 的接口可以直接使用 [THUDM/GLM-4](https://github.com/THUDM/GLM-4) 的形式，只在本项目启动需要的量化模型即可。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ $env:HF_ENDPOINT = "https://hf-mirror.com"
 | [DeepSeek-R1-Distill-Llama-8B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B) | 中英   |❌️| 47.2 GiB                                            |
 | [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B) | 中英   |❌️| 48.0 GiB 以上                                           |
 | [Ollama](https://github.com/ollama/ollama)                   | 多语     | ✅️        | 取决于本地模型 |
+| [legraphista/glm-4-9b-chat-GGUF](https://huggingface.co/legraphista/glm-4-9b-chat-GGUF)                        | 中英   |     ❌️     | 2-Bit 量化 3.99 GiB <br> 3-bit 量化 4.43 GiB - 5.28 GiB <br> 4-bit 量化 5.3 GiB - 5.51 GiB <br> 5-bit 量化 6.69 GiB <br> 6-bit 量化 8.26 GiB <br> 8-bit 量化 9.99 GiB|
 
 > [!NOTE]
 >
@@ -119,6 +120,7 @@ $env:HF_ENDPOINT = "https://hf-mirror.com"
 > 5. [DeepSeek-R1-Distill-Llama-8B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B) 支持双卡推理，但是存在语句异常中断问题，原因不详。
 > 6. [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B) 支持双卡推理，但是其显存已经超出两张 NVIDIA GeForce RTX 4090 的极限。
 > 7. [Ollama](https://github.com/ollama/ollama) 确保本机已安装并启动 **Ollama 服务**。
+> 8. [legraphista/glm-4-9b-chat-GGUF](https://huggingface.co/legraphista/glm-4-9b-chat-GGUF) 是基于 [THUDM/GLM-4](https://github.com/THUDM/GLM-4) 的量化模型版本，因此除了本项目启动时需要设置模型 id 以外，其他项目例如 [ZerolanLiveRobot](https://github.com/AkagawaTsurunaki/ZerolanLiveRobot) 完全继承了 [THUDM/GLM-4](https://github.com/THUDM/GLM-4) 的接口。
 
 ---
 
@@ -696,6 +698,47 @@ pymilvus.exceptions.MilvusException: <MilvusException: (code=100, message=Can no
 ```
 
 这代表连接成功。
+
+---
+
+### 防御模型
+
+提示词注入攻击通过插入或修改提示来操纵语言模型，从而触发有害或非预期响应。防御模型旨在通过检测这些恶意干预，来增强语言模型应用程序的安全性。
+
+| 模型名称                                                                                                                                                                        | 支持语言 | 显存占用    |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----|---------|
+| [protectai/deberta-v3-base-prompt-injection-v2](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2?text=111) | 中英 | 738 MB |
+
+> [!NOTE]
+>
+> 1. [protectai/deberta-v3-base-prompt-injection-v2](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2?text=111) 不建议使用此扫描器检查包含自行设计的系统提示词的内容，因为它会产生较高概率的**误报 (false-positives)**。
+
+---
+
+使用以下命令创建 [protectai/deberta-v3-base-prompt-injection-v2](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2?text=111) 的环境并启动模型。
+
+如果使用 `uv`，运行：
+
+```shell
+cd defense/deberta
+uv sync
+source .venv/bin/activate
+cd ../../
+uv run starter.py defense
+```
+
+如果使用 `Anaconda`，运行：
+
+```shell
+cd defense/deberta
+conda create --name deberta python==3.11 --yes
+conda activate deberta
+pip install -e .
+cd ../../
+python starter.py defense
+```
+
+---
 
 ## License
 

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -25,6 +25,11 @@ LLM:
       model_path: "THUDM/glm-4-9b-chat-hf"
       device: "cuda"
       max_length: 5000
+    legraphista/glm-4-9b-chat-GGUF:
+      model_path: "legraphista/glm-4-9b-chat-GGUF"  # Directory of the .gguf model including the local model file name, otherwise download the model
+      max_length: 5000
+      n_gpu_layers: -1  # -1 means all layers loaded into GPU, while 0 means loaded into CPU only
+      filename: "glm-4-9b-chat.Q2_K.gguf" # Download specific quantited model if it doesn't exist, exact filename please refer to https://huggingface.co/legraphista/glm-4-9b-chat-GGUF
     THUDM/chatglm3-6b:
       model_path: "THUDM/chatglm3-6b" # Directory of the model
       quantize: null  # null | 4 | 8
@@ -107,3 +112,13 @@ VidCap:
   config:
     iic/multi-modal_hitea_video-captioning_base_en:
       model_path: "iic/multi-modal_hitea_video-captioning_base_en" # Directory of the model
+
+Defense:
+  id: "protectai/deberta-v3-base-prompt-injection-v2"
+  host: "0.0.0.0"
+  port: 11012
+  config:
+    protectai/deberta-v3-base-prompt-injection-v2:
+      model_path: "protectai/deberta-v3-base-prompt-injection-v2"
+      max_length: 256
+      device: "cuda"

--- a/defense/app.py
+++ b/defense/app.py
@@ -1,0 +1,59 @@
+from flask import Flask, jsonify, request, Response, stream_with_context
+from loguru import logger
+from zerolan.data.pipeline.llm import LLMQuery, LLMPrediction
+
+from common.abs_app import AbstractApplication
+from common.abs_model import AbstractModel
+
+
+class DenfenseLLMApplication(AbstractApplication):
+
+    def __init__(self, model: AbstractModel, host: str, port: int):
+        super().__init__(model, "llm")
+        self.host = host
+        self.port = port
+        self._app = Flask(__name__)
+
+    def run(self):
+        self.model.load_model()
+        self.init()
+        self._app.run(self.host, self.port, False)
+
+    def init(self):
+        @self._app.route("/defense/predict", methods=["POST"])
+        def handle_predict():
+            llm_query = self._to_pipeline_format()
+            p: LLMPrediction = self.model.predict(llm_query)
+            logger.info(f'Model response: {p.response}')
+            return Response(
+                response=p.model_dump_json(),
+                status=200,
+                mimetype='application/json',
+                headers={'Content-Type': 'application/json; charset=utf-8'}
+            )
+
+        @self._app.route("/defense/stream-predict", methods=["POST"])
+        def handle_stream_predict():
+            # TODO: Will change in the later version.
+            llm_query = self._to_pipeline_format()
+
+            def generate_output(q: LLMQuery):
+                with self._app.app_context():
+                    for p in self.model.stream_predict(q):
+                        p: LLMPrediction
+                        logger.info(f'Model response (stream): {p.response}')
+                        yield p.model_dump_json() + '\n'
+
+            return Response(
+                stream_with_context(generate_output(llm_query)),
+                mimetype='application/json',
+                headers={'Content-Type': 'application/json; charset=utf-8'}
+            )
+
+    def _to_pipeline_format(self) -> LLMQuery:
+        with self._app.app_context():
+            logger.info('Query received: processing...')
+            json_val = request.get_json()
+            llm_query = LLMQuery.model_validate(json_val)
+            logger.info(f'User Input {llm_query.text}')
+            return llm_query

--- a/defense/deberta/config.py
+++ b/defense/deberta/config.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DebertaPromptDefenseModelConfig:
+    model_path: str = "protectai/deberta-v3-base-prompt-injection-v2"
+    device: str = "cuda"
+    max_length: int = 256

--- a/defense/deberta/model.py
+++ b/defense/deberta/model.py
@@ -1,0 +1,60 @@
+"""
+More details about the model:
+    https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2
+"""
+import torch
+from loguru import logger
+from transformers import AutoTokenizer, AutoModelForSequenceClassification, pipeline
+from zerolan.data.pipeline.llm import LLMQuery, LLMPrediction, Conversation, RoleEnum
+
+from common.abs_model import AbstractModel
+from common.decorator import log_model_loading
+from defense.deberta.config import DebertaPromptDefenseModelConfig
+
+
+class DebertaPromptDefenseModel(AbstractModel):
+
+    def __init__(self, config: DebertaPromptDefenseModelConfig):
+        super().__init__()
+        self.model_id = "protectai/deberta-v3-base-prompt-injection-v2"
+        self._model_path = config.model_path
+        self._device = torch.device("cuda" if torch.cuda.is_available() and config.device == "cuda" else "cpu"),
+        self._max_length = config.max_length
+
+        self._tokenizer: any = None
+        self._model: any = None
+
+    @log_model_loading("protectai/deberta-v3-base-prompt-injection-v2")
+    def load_model(self):
+        self._tokenizer = AutoTokenizer.from_pretrained(self._model_path, trust_remote_code=True)
+        self._model = AutoModelForSequenceClassification.from_pretrained(self._model_path).eval()
+
+    def predict(self, llm_query: LLMQuery) -> LLMPrediction:
+        classifier = pipeline(
+            "text-classification",
+            model=self._model,
+            tokenizer=self._tokenizer,
+            max_length=self._max_length,
+            truncation=True,
+            device=self._device
+        )
+
+        """
+        模型输出格式
+        [{'label': 'INJECTION', 'score': 0.99998}]
+        [{'label': 'SAFE', 'score': 0.93331}]
+        """
+        output = classifier(llm_query.text)
+        # logger.debug(f'Defense Model Output: {output}')
+
+        return self.to_pipeline_format(output[0], llm_query.history)
+
+    def stream_predict(self, llm_query: LLMQuery):
+        raise NotImplementedError()
+    
+    @staticmethod
+    def to_pipeline_format(output: str, history: list[Conversation]):
+        history.append(Conversation(role=RoleEnum.function, content=output['label'], metadata=str(output['score'])))
+        # 模型输出传输形式 response
+        response = f"{output['label']}|{str(output['score'])}"
+        return LLMPrediction(response=response, history=history)

--- a/defense/deberta/pyproject.toml
+++ b/defense/deberta/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "torch>=2.5.0",
     "torchvision>=0.20.0",
     "transformers>=4.46.0",
-    "llama-cpp-python==0.3.16"
     "zerolan-data",
 ]
 

--- a/llm/glm4/config.py
+++ b/llm/glm4/config.py
@@ -6,3 +6,11 @@ class GLM4ModelConfig:
     model_path: str = "THUDM/glm-4-9b-chat-hf"
     device: str = "cuda"
     max_length: int = 5000
+
+
+@dataclass
+class GLM4QuantitedModelConfig:
+    model_path: str = "legraphista/glm-4-9b-chat-GGUF"
+    max_length: int = 10000
+    n_gpu_layers: int = -1
+    filename: str = "glm-4-9b-chat.Q2_K.gguf"

--- a/llm/glm4/quantited_model.py
+++ b/llm/glm4/quantited_model.py
@@ -1,0 +1,85 @@
+"""
+More details about this model:
+    https://huggingface.co/legraphista/glm-4-9b-chat-GGUF
+"""
+try:
+    from llama_cpp import Llama
+except Exception as e:
+    raise Exception(e)
+# import torch
+# from transformers import AutoModelForCausalLM, AutoTokenizer
+import os
+from loguru import logger
+from zerolan.data.pipeline.llm import LLMQuery, LLMPrediction, Conversation, RoleEnum
+
+from common.abs_model import AbstractModel
+from common.decorator import log_model_loading
+from llm.glm4.config import GLM4QuantitedModelConfig
+
+
+class GLM4_9b_chat_GGUF(AbstractModel):
+
+    def __init__(self, config: GLM4QuantitedModelConfig):
+        super().__init__()
+        self.model_id = "legraphista/glm-4-9b-chat-GGUF"
+        self._model_path = config.model_path
+        self._max_length = config.max_length
+        self._n_gpu_layers = config.n_gpu_layers    # -1 表示全部层卸载到 GPU，0 表示纯 CPU
+        self._filename = config.filename
+
+        self._model: any = None
+
+    @log_model_loading("legraphista/glm-4-9b-chat-GGUF")
+    def load_model(self):
+        # GGUF 格式将分词器和权重打包在一起，无需单独加载 AutoTokenizer
+        if os.path.exists(self._model_path) and os.path.isfile(self._model_path):
+            # 本地存在模型
+            self._model = Llama(
+                model_path=self._model_path,
+                n_ctx=self._max_length,            # 上下文长度
+                n_gpu_layers=self._n_gpu_layers, # 将多少层卸载到GPU，-1表示全部卸载
+                chat_format="chatglm3",
+                verbose=False                 # 是否打印详细日志
+            )
+        else:
+            # huggingface 拉取模型，必要前提是已经执行 pip install huggingface-hub
+            self._model = Llama.from_pretrained(
+                repo_id="THUDM/glm-4-9b-chat-gguf",  # 目标仓库 ID
+                filename=self._filename,  # 下载指定量化版本，具体参数参考 huggingface 链接
+                n_ctx=self._max_length,
+                n_gpu_layers=self._n_gpu_layers,
+                chat_format="chatglm3",
+                verbose=False
+            )
+
+
+    def predict(self, llm_query: LLMQuery) -> LLMPrediction:
+        messages = self.to_glm4chat_format(llm_query)
+
+        # 直接调用 create_chat_completion，它会自动处理模板和 Tokenize
+        response = self._model.create_chat_completion(
+            messages=messages,
+            max_tokens=self._max_length,
+            temperature=0.7,
+            top_k=1,
+            stream=False
+        )
+
+        output = response["choices"][0]["message"]["content"]
+        # logger.debug(output)
+
+        return self.to_pipeline_format(output, llm_query.history)
+
+    def stream_predict(self, llm_query: LLMQuery):
+        raise NotImplementedError()
+
+    @staticmethod
+    def to_glm4chat_format(llm_query: LLMQuery):
+        messages = [{"role": chat.role, "content": chat.content} for chat in llm_query.history]
+        messages.append({"role": "user", "content": llm_query.text})
+        return messages
+    
+    @staticmethod
+    def to_pipeline_format(output: str, history: list[Conversation]):
+        history.append(Conversation(role=RoleEnum.assistant, content=output))
+        return LLMPrediction(response=output, history=history)

--- a/starter.py
+++ b/starter.py
@@ -75,6 +75,10 @@ def llm_app() -> AbstractApplication:
             from llm.glm4.model import GLM4_9B_Chat_Hf as Model
             from llm.glm4.config import GLM4ModelConfig as Config
             return Model(Config(**model_cfg))
+        elif llm_id == "legraphista/glm-4-9b-chat-GGUF":
+            from llm.glm4.quantited_model import GLM4_9b_chat_GGUF as Model
+            from llm.glm4.config import GLM4QuantitedModelConfig as Config
+            return Model(Config(**model_cfg))
         elif llm_id in ["deepseek-ai/DeepSeek-R1-Distill-Llama-8B", "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"]:
             from llm.deepseek.model import DeepSeekLLMModel as Model
             from llm.deepseek.config import DeepSeekModelConfig as Config
@@ -193,6 +197,26 @@ def vidcap_app():
     return app
 
 
+def defense_app():
+    from defense.app import DenfenseLLMApplication
+
+    defense_config = _config["Defense"]
+    host, port = defense_config["host"], defense_config["port"]
+    model_id = defense_config["id"]
+    model_cfg = defense_config["config"][model_id]
+
+    def get_model():
+        if model_id == "protectai/deberta-v3-base-prompt-injection-v2":
+            from defense.deberta.model import DebertaPromptDefenseModel as Model
+            from defense.deberta.config import DebertaPromptDefenseModelConfig as Config
+            return Model(Config(**model_cfg))
+        
+    defense = get_model()
+    app = DenfenseLLMApplication(
+        model=defense, host=host, port=port)
+    return app
+
+
 def get_app(service):
     if "asr" == service:
         return asr_app()
@@ -210,6 +234,8 @@ def get_app(service):
         return vecdb_app(args.db)
     elif "vidcap" == service:
         return vidcap_app()
+    elif "defense" == service:
+        return defense_app()
     else:
         raise NotImplementedError("Unsupported service.")
 


### PR DESCRIPTION
# Core

### 1.glm4量化模型✔
由于该模型为 glm4 的量化版本，因此我直接在 llm/glm4 下实现代码，并将额外的环境依赖 Llama 手动加入了 pyproject.toml；
同样的，我选择直接在 llm/glm4/ 下实现了量化模型的接口 quantited_model.py
已经过测试，可以在 windows11 环境下与 LiveRobot 项目通信，并且 LiveRobot 的接口可以直接使用 glm4 无需切换，这一点已经在 README 内说明

### 2.防御模型✔
新增了一个 defense 类型，以及一个模型 deberta
我偷懒直接用了 glm4-9b-chat-hf 的环境来跑发现没有问题，所以就直接把那边的 pyproject.toml 拿过来了，但是 uv.lock 我不会用就没搬过来，不过 README.md 内我描述时是把两种部署方式都放上去了，所以如果不加 uv.lock 方式的话麻烦把 README.md 第一种方式删掉
已经过测试，可以在 windows11 环境下与 LiveRobot 项目通信，但是似乎过于奇怪的弹幕会先一步被b站弹幕姬捕获然后丢弃(?)